### PR TITLE
Replace option hash with named arguments

### DIFF
--- a/regress/basic_connectivity.rb
+++ b/regress/basic_connectivity.rb
@@ -11,7 +11,7 @@ Harness.run_test do
   server = start_websocket_server
 
   log 'Set a handler for receiving text on the server'
-  server.on(:text) do |conn, payload|
+  server.on_text do |conn, payload|
     log "Received #{payload.string} as server"
     log 'Send text from the server back to the client'
     conn.send_frame(1, 'Hello!')
@@ -22,7 +22,7 @@ Harness.run_test do
   client = connect_client
   client.serve!
   log 'Set a handler for receiving text on the client'
-  client.on(:text) do |_conn, payload|
+  client.on_text do |_conn, payload|
     log "Received #{payload.string} as client"
     client_received = true
   end

--- a/regress/basic_connectivity.rb.baseline
+++ b/regress/basic_connectivity.rb.baseline
@@ -18,5 +18,3 @@ Stop the client
 
 INFO    Listening on localhost:[WEBSOCKET_PORT]
 INFO    Received websocket key, establishing connection
-INFO    Payload size: 6 B
-INFO    Payload size: 6 B

--- a/regress/basic_ssl_connectivity.rb
+++ b/regress/basic_ssl_connectivity.rb
@@ -13,7 +13,7 @@ Harness.run_test(ssl: true,
   server = start_websocket_server
 
   log 'Set a handler for receiving text on the server'
-  server.on(:text) do |conn, payload|
+  server.on_text do |conn, payload|
     log "Received #{payload.string} as server"
     log 'Send text from the server back to the client'
     conn.send_frame(1, 'Hello!')
@@ -24,7 +24,7 @@ Harness.run_test(ssl: true,
   client = connect_client(ssl: true, ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE)
   client.serve!
   log 'Set a handler for receiving text on the client'
-  client.on(:text) do |_conn, payload|
+  client.on_text do |_conn, payload|
     log "Received #{payload.string} as client"
     client_received = true
   end

--- a/regress/basic_ssl_connectivity.rb.baseline
+++ b/regress/basic_ssl_connectivity.rb.baseline
@@ -19,5 +19,3 @@ Stop the client
 INFO    Listening on localhost:[WEBSOCKET_PORT]
 INFO    Initializing SSL context
 INFO    Received websocket key, establishing connection
-INFO    Payload size: 6 B
-INFO    Payload size: 6 B

--- a/regress/client_slow_message_transfer.rb
+++ b/regress/client_slow_message_transfer.rb
@@ -8,12 +8,12 @@ Harness.run_test do
   server_disconnected = false
   log 'Start websocket server'
   server = start_websocket_server
-  server.on(:client_disconnect) do |_client|
+  server.on_client_disconnect do |_client|
     log 'Server has disconnected from a client'
     server_disconnected = true
   end
 
-  server.on(:text) do |_client, body|
+  server.on_text do |_client, body|
     log "Server received text from client: #{body.length} B"
   end
 

--- a/regress/client_slow_message_transfer.rb.baseline
+++ b/regress/client_slow_message_transfer.rb.baseline
@@ -12,4 +12,3 @@ Server has disconnected from a client
 
 INFO    Listening on localhost:[WEBSOCKET_PORT]
 INFO    Received websocket key, establishing connection
-INFO    Payload size: 8192 B

--- a/regress/close_by_client.rb
+++ b/regress/close_by_client.rb
@@ -12,11 +12,11 @@ Harness.run_test do
   server = start_websocket_server
 
   log 'Set a handler for receiving close events from the server'
-  server.on(:close) do |_c, payload|
+  server.on_close do |_c, payload|
     log "Received close with #{payload.string.inspect} as server"
   end
 
-  server.on(:client_disconnect) do |_client|
+  server.on_client_disconnect do |_client|
     log 'Server has disconnected from a client'
     server_disconnected = true
   end
@@ -26,7 +26,7 @@ Harness.run_test do
   client.serve!
 
   log 'Set a handler for receiving close events from the client'
-  client.on(:close) do |_c, payload|
+  client.on_close do |_c, payload|
     client_received = "Received close with #{payload.string.inspect} as client"
   end
 

--- a/regress/close_by_client.rb.baseline
+++ b/regress/close_by_client.rb.baseline
@@ -18,6 +18,4 @@ Stop websocket server
 
 INFO    Listening on localhost:[WEBSOCKET_PORT]
 INFO    Received websocket key, establishing connection
-INFO    Payload size: 0 B
-INFO    Payload size: 0 B
 INFO    Stopping WebSocket server

--- a/regress/close_by_server.rb
+++ b/regress/close_by_server.rb
@@ -11,12 +11,12 @@ Harness.run_test do
   server = start_websocket_server
 
   log 'Set a handler for receiving close events from the server'
-  server.on(:close) do |_c, payload|
+  server.on_close do |_c, payload|
     log "Received close with #{payload.string.inspect} as server"
     server_received = true
   end
 
-  server.on(:ping) do |client|
+  server.on_ping do |client|
     client.send_frame(:close)
   end
 
@@ -24,7 +24,7 @@ Harness.run_test do
   client = connect_client
 
   log 'Set a handler for receiving close events from the client'
-  client.on(:close) do |_c, payload|
+  client.on_close do |_c, payload|
     log "Received close with #{payload.string.inspect} as client"
   end
 

--- a/regress/close_by_server.rb.baseline
+++ b/regress/close_by_server.rb.baseline
@@ -16,7 +16,4 @@ Stop websocket server
 
 INFO    Listening on localhost:[WEBSOCKET_PORT]
 INFO    Received websocket key, establishing connection
-INFO    Payload size: 0 B
-INFO    Payload size: 0 B
-INFO    Payload size: 0 B
 INFO    Stopping WebSocket server

--- a/regress/disconnect_during_client_body.rb
+++ b/regress/disconnect_during_client_body.rb
@@ -8,12 +8,12 @@ Harness.run_test do
   server_disconnected = false
   log 'Start websocket server'
   server = start_websocket_server
-  server.on(:client_disconnect) do |_client|
+  server.on_client_disconnect do |_client|
     log 'Server has disconnected from a client'
     server_disconnected = true
   end
 
-  server.on(:text) do |_client, body|
+  server.on_text do |_client, body|
     log "Server received text from client: #{body.string.inspect}"
   end
 

--- a/regress/disconnect_during_client_body.rb.baseline
+++ b/regress/disconnect_during_client_body.rb.baseline
@@ -23,13 +23,9 @@ Server has disconnected from a client
 
 INFO    Listening on localhost:[WEBSOCKET_PORT]
 INFO    Received websocket key, establishing connection
-INFO    Payload size: 3 B
 ERROR   Socket closed unexpectedly during message transfer
 INFO    Received websocket key, establishing connection
-INFO    Payload size: 3 B
 ERROR   Socket closed unexpectedly during message transfer
 INFO    Received websocket key, establishing connection
-INFO    Payload size: 3 B
 ERROR   Socket closed unexpectedly during message transfer
 INFO    Received websocket key, establishing connection
-INFO    Payload size: 3 B

--- a/regress/disconnect_during_client_header.rb
+++ b/regress/disconnect_during_client_header.rb
@@ -8,7 +8,7 @@ Harness.run_test do
   server_disconnected = false
   log 'Start websocket server'
   server = start_websocket_server
-  server.on(:client_disconnect) do |_client|
+  server.on_client_disconnect do |_client|
     log 'Server has disconnected from a client'
     server_disconnected = true
   end

--- a/regress/disconnect_during_client_header.rb.baseline
+++ b/regress/disconnect_during_client_header.rb.baseline
@@ -36,14 +36,10 @@ ERROR   Socket closed unexpectedly during length transfer
 INFO    Received websocket key, establishing connection
 ERROR   Socket closed unexpectedly during length transfer
 INFO    Received websocket key, establishing connection
-INFO    Payload size: 65535 B
 ERROR   Socket closed unexpectedly during mask transfer
 INFO    Received websocket key, establishing connection
-INFO    Payload size: 1 B
 ERROR   Socket closed unexpectedly during mask transfer
 INFO    Received websocket key, establishing connection
-INFO    Payload size: 1 B
 ERROR   Socket closed unexpectedly during mask transfer
 INFO    Received websocket key, establishing connection
-INFO    Payload size: 1 B
 ERROR   Socket closed unexpectedly during message transfer

--- a/regress/extra_websocket_header_extension.rb
+++ b/regress/extra_websocket_header_extension.rb
@@ -11,7 +11,7 @@ Harness.run_test do
   server = start_websocket_server
 
   log 'Set a handler for receiving server connect and disconnect events'
-  server.on(:client_connect) do |client|
+  server.on_client_connect do |client|
     log 'Server has connected to a client'
     log "Client path: #{client.path}"
     log "Client host: #{client.host}"
@@ -19,7 +19,7 @@ Harness.run_test do
     server_connected = true
   end
 
-  server.on(:client_disconnect) do |_client|
+  server.on_client_disconnect do |_client|
     log 'Server has disconnected from a client'
     server_disconnected = true
   end

--- a/regress/harness.rb
+++ b/regress/harness.rb
@@ -42,7 +42,7 @@ class Harness
       ssl_cert: @cert,
       ssl_key: @key
     }
-    @socket_server = WebSocket::Server.new(options)
+    @socket_server = WebSocket::Server.new(**options)
     @socket_server.run!
     @socket_server
   end
@@ -62,7 +62,7 @@ class Harness
 
   def connect_client(opts = {})
     Timeout::timeout(1) do
-      WebSocket::Client.connect(@host, @port, opts.merge(logger: make_logger))
+      WebSocket::Client.connect(@host, @port, **opts.merge(logger: make_logger))
     end
   end
 

--- a/regress/invalid_client_request_connection_header.rb
+++ b/regress/invalid_client_request_connection_header.rb
@@ -11,12 +11,12 @@ Harness.run_test do
   server = start_websocket_server
 
   log 'Set a handler for receiving server connect and disconnect events'
-  server.on(:client_connect) do |_client|
+  server.on_client_connect do |_client|
     log 'Server has connected to a client'
     server_connected = true
   end
 
-  server.on(:client_disconnect) do |_client|
+  server.on_client_disconnect do |_client|
     log 'Server has disconnected from a client'
     server_disconnected = true
   end

--- a/regress/invalid_client_request_host_header.rb
+++ b/regress/invalid_client_request_host_header.rb
@@ -11,12 +11,12 @@ Harness.run_test do
   server = start_websocket_server
 
   log 'Set a handler for receiving server connect and disconnect events'
-  server.on(:client_connect) do |_client|
+  server.on_client_connect do |_client|
     log 'Server has connected to a client'
     server_connected = true
   end
 
-  server.on(:client_disconnect) do |_client|
+  server.on_client_disconnect do |_client|
     log 'Server has disconnected from a client'
     server_disconnected = true
   end

--- a/regress/invalid_client_request_socket_key.rb
+++ b/regress/invalid_client_request_socket_key.rb
@@ -11,12 +11,12 @@ Harness.run_test do
   server = start_websocket_server
 
   log 'Set a handler for receiving server connect and disconnect events'
-  server.on(:client_connect) do |_client|
+  server.on_client_connect do |_client|
     log 'Server has connected to a client'
     server_connected = true
   end
 
-  server.on(:client_disconnect) do |_client|
+  server.on_client_disconnect do |_client|
     log 'Server has disconnected from a client'
     server_disconnected = true
   end

--- a/regress/invalid_client_request_socket_version.rb
+++ b/regress/invalid_client_request_socket_version.rb
@@ -11,12 +11,12 @@ Harness.run_test do
   server = start_websocket_server
 
   log 'Set a handler for receiving server connect and disconnect events'
-  server.on(:client_connect) do |_client|
+  server.on_client_connect do |_client|
     log 'Server has connected to a client'
     server_connected = true
   end
 
-  server.on(:client_disconnect) do |_client|
+  server.on_client_disconnect do |_client|
     log 'Server has disconnected from a client'
     server_disconnected = true
   end

--- a/regress/invalid_client_request_upgrade_header.rb
+++ b/regress/invalid_client_request_upgrade_header.rb
@@ -11,12 +11,12 @@ Harness.run_test do
   server = start_websocket_server
 
   log 'Set a handler for receiving server connect and disconnect events'
-  server.on(:client_connect) do |_client|
+  server.on_client_connect do |_client|
     log 'Server has connected to a client'
     server_connected = true
   end
 
-  server.on(:client_disconnect) do |_client|
+  server.on_client_disconnect do |_client|
     log 'Server has disconnected from a client'
     server_disconnected = true
   end

--- a/regress/invalid_client_request_verb.rb
+++ b/regress/invalid_client_request_verb.rb
@@ -11,12 +11,12 @@ Harness.run_test do
   server = start_websocket_server
 
   log 'Set a handler for receiving server connect and disconnect events'
-  server.on(:client_connect) do |_client|
+  server.on_client_connect do |_client|
     log 'Server has connected to a client'
     server_connected = true
   end
 
-  server.on(:client_disconnect) do |_client|
+  server.on_client_disconnect do |_client|
     log 'Server has disconnected from a client'
     server_disconnected = true
   end

--- a/regress/payload_1024B.rb
+++ b/regress/payload_1024B.rb
@@ -13,7 +13,7 @@ Harness.run_test do
   server = start_websocket_server
 
   log 'Set a handler for receiving text on the server'
-  server.on(:text) do |conn, payload|
+  server.on_text do |conn, payload|
     log "Server message matches? #{payload.string == client_message}"
     log 'Send text from the server back to the client'
     conn.send_frame(1, server_message)
@@ -24,7 +24,7 @@ Harness.run_test do
   client = connect_client
   client.serve!
   log 'Set a handler for receiving text on the client'
-  client.on(:text) do |_conn, payload|
+  client.on_text do |_conn, payload|
     log "Client message matches? #{payload.string == server_message}"
     client_received = true
   end

--- a/regress/payload_1024B.rb.baseline
+++ b/regress/payload_1024B.rb.baseline
@@ -18,5 +18,3 @@ Stop the client
 
 INFO    Listening on localhost:[WEBSOCKET_PORT]
 INFO    Received websocket key, establishing connection
-INFO    Payload size: 1024 B
-INFO    Payload size: 1024 B

--- a/regress/payload_1025B.rb
+++ b/regress/payload_1025B.rb
@@ -13,7 +13,7 @@ Harness.run_test do
   server = start_websocket_server
 
   log 'Set a handler for receiving text on the server'
-  server.on(:text) do |conn, payload|
+  server.on_text do |conn, payload|
     log "Server message matches? #{payload.string == client_message}"
     log 'Send text from the server back to the client'
     conn.send_frame(1, server_message)
@@ -24,7 +24,7 @@ Harness.run_test do
   client = connect_client
   client.serve!
   log 'Set a handler for receiving text on the client'
-  client.on(:text) do |_conn, payload|
+  client.on_text do |_conn, payload|
     log "Client message matches? #{payload.string == server_message}"
     client_received = true
   end

--- a/regress/payload_1025B.rb.baseline
+++ b/regress/payload_1025B.rb.baseline
@@ -18,5 +18,3 @@ Stop the client
 
 INFO    Listening on localhost:[WEBSOCKET_PORT]
 INFO    Received websocket key, establishing connection
-INFO    Payload size: 1025 B
-INFO    Payload size: 1025 B

--- a/regress/payload_125B.rb
+++ b/regress/payload_125B.rb
@@ -11,7 +11,7 @@ Harness.run_test do
   server = start_websocket_server
 
   log 'Set a handler for receiving text on the server'
-  server.on(:text) do |conn, payload|
+  server.on_text do |conn, payload|
     log "Received #{payload.string} as server"
     log 'Send text from the server back to the client'
     conn.send_frame(1, 'Hello' * 25)
@@ -22,7 +22,7 @@ Harness.run_test do
   client = connect_client
   client.serve!
   log 'Set a handler for receiving text on the client'
-  client.on(:text) do |_conn, payload|
+  client.on_text do |_conn, payload|
     log "Received #{payload.string} as client"
     client_received = true
   end

--- a/regress/payload_125B.rb.baseline
+++ b/regress/payload_125B.rb.baseline
@@ -18,5 +18,3 @@ Stop the client
 
 INFO    Listening on localhost:[WEBSOCKET_PORT]
 INFO    Received websocket key, establishing connection
-INFO    Payload size: 125 B
-INFO    Payload size: 125 B

--- a/regress/payload_126B.rb
+++ b/regress/payload_126B.rb
@@ -11,7 +11,7 @@ Harness.run_test do
   server = start_websocket_server
 
   log 'Set a handler for receiving text on the server'
-  server.on(:text) do |conn, payload|
+  server.on_text do |conn, payload|
     log "Received #{payload.string} as server"
     log 'Send text from the server back to the client'
     conn.send_frame(1, ('Hello' * 25) + '!')
@@ -22,7 +22,7 @@ Harness.run_test do
   client = connect_client
   client.serve!
   log 'Set a handler for receiving text on the client'
-  client.on(:text) do |_conn, payload|
+  client.on_text do |_conn, payload|
     log "Received #{payload.string} as client"
     client_received = true
   end

--- a/regress/payload_126B.rb.baseline
+++ b/regress/payload_126B.rb.baseline
@@ -18,5 +18,3 @@ Stop the client
 
 INFO    Listening on localhost:[WEBSOCKET_PORT]
 INFO    Received websocket key, establishing connection
-INFO    Payload size: 126 B
-INFO    Payload size: 126 B

--- a/regress/payload_127B.rb
+++ b/regress/payload_127B.rb
@@ -11,7 +11,7 @@ Harness.run_test do
   server = start_websocket_server
 
   log 'Set a handler for receiving text on the server'
-  server.on(:text) do |conn, payload|
+  server.on_text do |conn, payload|
     log "Received #{payload.string} as server"
     log 'Send text from the server back to the client'
     conn.send_frame(1, ('Hello' * 25) + '!!')
@@ -22,7 +22,7 @@ Harness.run_test do
   client = connect_client
   client.serve!
   log 'Set a handler for receiving text on the client'
-  client.on(:text) do |_conn, payload|
+  client.on_text do |_conn, payload|
     log "Received #{payload.string} as client"
     client_received = true
   end

--- a/regress/payload_127B.rb.baseline
+++ b/regress/payload_127B.rb.baseline
@@ -18,5 +18,3 @@ Stop the client
 
 INFO    Listening on localhost:[WEBSOCKET_PORT]
 INFO    Received websocket key, establishing connection
-INFO    Payload size: 127 B
-INFO    Payload size: 127 B

--- a/regress/payload_65535B.rb
+++ b/regress/payload_65535B.rb
@@ -13,7 +13,7 @@ Harness.run_test do
   server = start_websocket_server
 
   log 'Set a handler for receiving text on the server'
-  server.on(:text) do |conn, payload|
+  server.on_text do |conn, payload|
     log "Server message matches? #{payload.string == client_message}"
     log 'Send text from the server back to the client'
     conn.send_frame(1, server_message)
@@ -24,7 +24,7 @@ Harness.run_test do
   client = connect_client
   client.serve!
   log 'Set a handler for receiving text on the client'
-  client.on(:text) do |_conn, payload|
+  client.on_text do |_conn, payload|
     log "Client message matches? #{payload.string == server_message}"
     client_received = true
   end

--- a/regress/payload_65535B.rb.baseline
+++ b/regress/payload_65535B.rb.baseline
@@ -18,5 +18,3 @@ Stop the client
 
 INFO    Listening on localhost:[WEBSOCKET_PORT]
 INFO    Received websocket key, establishing connection
-INFO    Payload size: 65535 B
-INFO    Payload size: 65535 B

--- a/regress/payload_65536B.rb
+++ b/regress/payload_65536B.rb
@@ -13,7 +13,7 @@ Harness.run_test do
   server = start_websocket_server
 
   log 'Set a handler for receiving text on the server'
-  server.on(:text) do |conn, payload|
+  server.on_text do |conn, payload|
     log "Server message matches? #{payload.string == client_message}"
     log 'Send text from the server back to the client'
     conn.send_frame(1, server_message)
@@ -24,7 +24,7 @@ Harness.run_test do
   client = connect_client
   client.serve!
   log 'Set a handler for receiving text on the client'
-  client.on(:text) do |_conn, payload|
+  client.on_text do |_conn, payload|
     log "Client message matches? #{payload.string == server_message}"
     client_received = true
   end

--- a/regress/payload_65536B.rb.baseline
+++ b/regress/payload_65536B.rb.baseline
@@ -18,7 +18,3 @@ Stop the client
 
 INFO    Listening on localhost:[WEBSOCKET_PORT]
 INFO    Received websocket key, establishing connection
-INFO    [0, 65536]
-INFO    Payload size: 65536 B
-INFO    [0, 65536]
-INFO    Payload size: 65536 B

--- a/regress/ping_pong.rb
+++ b/regress/ping_pong.rb
@@ -15,7 +15,7 @@ Harness.run_test do
   client.serve!
 
   log 'Set a handler for receiving pongs on the client'
-  client.on(:pong) do |_c, payload|
+  client.on_pong do |_c, payload|
     log "Received pong with #{payload.string} as client"
     client_received = true
   end
@@ -34,7 +34,7 @@ Harness.run_test do
   scenario 'Send a ping from the server to the client'
 
   log 'Set a handler for receiving pongs on the server'
-  server.on(:pong) do |_c, payload|
+  server.on_pong do |_c, payload|
     log "Received pong with #{payload.string} as server"
     server_received = true
   end

--- a/regress/ping_pong.rb.baseline
+++ b/regress/ping_pong.rb.baseline
@@ -21,7 +21,3 @@ Stop the client
 
 INFO    Listening on localhost:[WEBSOCKET_PORT]
 INFO    Received websocket key, establishing connection
-INFO    Payload size: 6 B
-INFO    Payload size: 6 B
-INFO    Payload size: 12 B
-INFO    Payload size: 12 B

--- a/regress/verbose_connection.rb
+++ b/regress/verbose_connection.rb
@@ -11,7 +11,7 @@ Harness.run_test do
   server = start_websocket_server
 
   log 'Set a handler for receiving server connect and disconnect events'
-  server.on(:client_connect) do |client|
+  server.on_client_connect do |client|
     log 'Server has connected to a client'
     log "Client path: #{client.path}"
     log "Client host: #{client.host}"
@@ -19,7 +19,7 @@ Harness.run_test do
     server_connected = true
   end
 
-  server.on(:client_disconnect) do |_client|
+  server.on_client_disconnect do |_client|
     log 'Server has disconnected from a client'
     server_disconnected = true
   end

--- a/websocket_server.rb
+++ b/websocket_server.rb
@@ -51,13 +51,14 @@ module WebSocket
     #   host: hostname from which to serve WebSockets
     #   port: port from which to serve WebSockets
     #   logger: logger override to use for log messages (defaults to STDOUT)
-    def initialize(opts = {})
-      @host = opts[:host]
-      @port = opts[:port]
-      @logger = opts[:logger]
-      @ssl = opts[:ssl]
-      @ssl_key = opts[:ssl_key]
-      @ssl_cert = opts[:ssl_cert]
+    def initialize(opts = {}, host: nil, port: nil, logger: nil, ssl: nil,
+                              ssl_key: nil, ssl_cert: nil)
+      @host = host || opts[:host]
+      @port = port || opts[:port]
+      @logger = logger || opts[:logger]
+      @ssl = ssl || opts[:ssl]
+      @ssl_key = ssl_key || opts[:ssl_key]
+      @ssl_cert = ssl_cert || opts[:ssl_cert]
       @client_handlers = Hash.new{|h, v| h[v] = []}
       @server_handlers = Hash.new{|h, v| h[v] = []}
       @clients = {}
@@ -85,6 +86,15 @@ module WebSocket
         @client_handlers[action] << func
       end
     end
+
+    # shortcuts
+    def on_text(func = nil, &block);   on(:text, func, &block)    end
+    def on_binary(func = nil, &block); on(:binary, func, &block)  end
+    def on_close(func = nil, &block);  on(:close, func, &block)   end
+    def on_ping(func = nil, &block);   on(:ping, func, &block)    end
+    def on_pong(func = nil, &block);   on(:pong, func, &block)    end
+    def on_client_connect(func = nil, &block); on(:client_connect, func, &block) end
+    def on_client_disconnect(func = nil, &block); on(:client_disconnect, func, &block) end
 
     # Starts the WebSocket server, spawns a new thread for every request
     def run!


### PR DESCRIPTION
# Overview

* Begins replacement of options hashes with named (keyword) arguments; leaves backwards-compatibility
* Adds convenience methods for `on_<message type>` (e.g.: `on(:text)` -> `on_text`)
* Removes overly-verbose logging from client and server libraries